### PR TITLE
feat: new api endpoints

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm
 
+RUN apt-get update && apt-get install -y just
+
 # Create non-root user with UID/GID commonly used by VS Code (1000:1000)
 RUN useradd -ms /bin/bash -u 1000 vscode \
     && apt-get update && apt-get install -y sudo \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "rdflib>=7.1.4",
     "SPARQLWrapper>=2.0.0",
     "rapidfuzz>=3.0.0",
+    "typer>=0.12.5",
 ]
 [dependency-groups]
 dev = [
@@ -27,7 +28,12 @@ dev = [
 ]
 
 [project.scripts]
-cli = 'strings2things.cli:main'
+# Primary multi-command CLI (Typer based)
+strings2things = 'strings2things.cli:app'
+# Shortcut to launch API server directly
+strings2things-serve = 'strings2things.cli:serve'
+# Backward compatibility alias if previous users relied on `cli`
+cli = 'strings2things.cli:app'
 
 [build-system]
 requires = ["hatchling"]

--- a/src/strings2things/app/api/endpoints.py
+++ b/src/strings2things/app/api/endpoints.py
@@ -1,55 +1,171 @@
-# app/api/endpoints.py
+"""RDF transformation API endpoints.
 
-from fastapi import APIRouter, UploadFile, File, Form
+We intentionally split raw-body and multipart upload into two endpoints so that
+the generated OpenAPI schema (Swagger UI) shows both usage patterns. A single
+endpoint mixing `UploadFile` with a normal JSON/Turtle body would appear only
+as `multipart/form-data` in the docs.
+
+Endpoints
+---------
+POST /v1/things         Raw JSON-LD (object/array) or Turtle string body
+POST /v1/things/upload  Multipart file upload
+
+Shared Parameters
+-----------------
+serialization  (required) jsonld | turtle
+fuzzy          (optional, default false)
+fuzzy_threshold (0-100, default 90)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+import json
+import logging
+from fastapi import APIRouter, UploadFile, File, Query, Form, Request, Body
 from fastapi.responses import Response
-from rdflib import Graph
+
 from strings2things.app.core.rdf_transformer import RDFTransformer
 from strings2things.app.core.ontology_manager import OntologyManager
 from strings2things.app.utils.rdf_utils import parse_rdf, serialize_rdf
-import logging
 
 router = APIRouter()
-
-ontology_manager = OntologyManager()
-ontology_manager.load_ontologies()
-
-# Keep transformer as a base instance
-base_label_map = ontology_manager.get_label_map()
+ontology_manager = OntologyManager()  # Lazy load on first access
 
 
-@router.post("/transform")
-async def transform_rdf(
-    file: UploadFile = File(...),
-    serialization: str = Form("turtle"),
-    fuzzy: bool = Form(False),  # <-- new parameter
-    fuzzy_threshold: int = Form(90),  # <-- configurable fuzzy matching threshold
+def _detect_input_format(content_type: str, data: bytes) -> str:
+    """Infer whether payload is JSON-LD or Turtle.
+
+    Uses explicit content-type when present; falls back to leading character
+    heuristic (object/array starts imply JSON-LD).
+    """
+    ct = (content_type or "").split(";")[0].strip().lower()
+    if ct in {"application/ld+json", "application/json"}:
+        return "json-ld"
+    if ct in {"text/turtle", "application/x-turtle", "text/plain"}:
+        return "turtle"
+    lead = data.lstrip()[:1]
+    return "json-ld" if lead in (b"{", b"[") else "turtle"
+
+
+def _label_map() -> dict[str, str]:
+    if not ontology_manager.get_label_map():
+        try:
+            ontology_manager.load_ontologies()
+        except Exception:  # pragma: no cover (resilience path)
+            logging.exception("Ontology loading failed; proceeding with empty label map")
+    return ontology_manager.get_label_map() or {}
+
+
+def _transform_bytes(
+    payload: bytes,
+    content_type: str,
+    serialization: Literal["jsonld", "turtle"],
+    fuzzy: bool,
+    fuzzy_threshold: int,
+) -> tuple[str, str]:
+    input_format = _detect_input_format(content_type, payload)
+    graph = parse_rdf(payload, format=input_format)
+    transformer = RDFTransformer(_label_map(), fuzzy=fuzzy, fuzzy_threshold=fuzzy_threshold)
+    transformed = transformer.transform(graph)
+    out_fmt = "json-ld" if serialization == "jsonld" else "turtle"
+    media_type = "application/ld+json" if out_fmt == "json-ld" else "text/turtle"
+    serialized = serialize_rdf(transformed, output_format=out_fmt)
+    return serialized, media_type
+
+
+@router.post(
+    "/v1/things",
+    tags=["transform"],
+    summary="Transform RDF (raw body)",
+    description=(
+        "Send RDF as either JSON-LD (application/ld+json or application/json) or plain Turtle (text/turtle or text/plain). "
+        "When sending Turtle, set the Content-Type header to text/turtle (no JSON wrapper needed)."
+    ),
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/ld+json": {
+                    "schema": {"type": "object", "description": "JSON-LD object graph"},
+                    "examples": {
+                        "jsonldObject": {
+                            "summary": "Minimal JSON-LD",
+                            "value": {"@context": {}, "@id": "_:b0", "name": "Example"},
+                        }
+                    },
+                },
+                "application/json": {
+                    "schema": {"type": "object", "description": "Interpreted as JSON-LD"},
+                    "examples": {
+                        "genericJson": {
+                            "summary": "Generic JSON treated as JSON-LD",
+                            "value": {"label": "Some Value"},
+                        }
+                    },
+                },
+                "text/turtle": {
+                    "schema": {"type": "string", "description": "Turtle serialization"},
+                    "examples": {
+                        "turtle": {
+                            "summary": "Turtle example",
+                            "value": "@prefix ex: <http://example/> . ex:s ex:p ex:o .",
+                        }
+                    },
+                },
+                "text/plain": {
+                    "schema": {"type": "string", "description": "Plain text (assumed Turtle)"}
+                },
+            },
+        }
+    },
+)
+async def transform_rdf_raw(
+    request: Request,
+    serialization: Literal["jsonld", "turtle"] = Query(..., description="Output format"),
+    fuzzy: bool = Query(False, description="Enable fuzzy matching"),
+    fuzzy_threshold: int = Query(90, ge=0, le=100, description="Fuzzy threshold 0-100"),
 ) -> Response:
-    """
-    Accepts an RDF file upload, transforms it using the label map,
-    and returns the modified RDF graph in the requested format.
+    """Accept raw body as JSON-LD or Turtle without requiring JSON wrapping for Turtle.
 
-    Args:
-        file: The uploaded RDF file
-        serialization: Desired output RDF serialization (default: turtle)
-        fuzzy: Whether to use fuzzy matching (default: False)
-        threshold: Similarity threshold for fuzzy matching (0-100, default: 90)
+    We read the raw bytes to allow multiple media types. Format detection uses
+    the Content-Type header first, then a leading character heuristic.
     """
-    content = await file.read()
-
     try:
-        input_graph = parse_rdf(content)
-
-        transformer = RDFTransformer(
-            base_label_map,
-            fuzzy=fuzzy,
-            fuzzy_threshold=fuzzy_threshold,
+        body = await request.body()
+        if not body:
+            return Response(content="Empty body", status_code=400)
+        content_type = request.headers.get("content-type", "")
+        serialized, media_type = _transform_bytes(
+            body, content_type, serialization, fuzzy, fuzzy_threshold
         )
-
-        transformed_graph = transformer.transform(input_graph)
-        serialized = serialize_rdf(transformed_graph, output_format=serialization)
-
-        return Response(content=serialized, media_type="text/plain")
-
-    except Exception as e:
+        return Response(content=serialized, media_type=media_type)
+    except Exception as e:  # pragma: no cover
         logging.exception("Transformation failed")
         return Response(content=str(e), status_code=400)
+
+
+@router.post(
+    "/v1/things/upload",
+    tags=["transform"],
+    summary="Transform RDF (file upload)",
+    description="Upload an RDF file (JSON-LD or Turtle) via multipart/form-data",
+)
+async def transform_rdf_upload(
+    file: UploadFile = File(..., description="RDF file (JSON-LD or Turtle)"),
+    serialization: Literal["jsonld", "turtle"] = Form(..., description="Output format"),
+    fuzzy: bool = Form(False, description="Enable fuzzy matching"),
+    fuzzy_threshold: int = Form(90, description="Fuzzy threshold 0-100"),
+) -> Response:
+    try:
+        data = await file.read()
+        if not data:
+            return Response(content="Uploaded file is empty", status_code=400)
+        serialized, media_type = _transform_bytes(
+            data, file.content_type or "", serialization, fuzzy, fuzzy_threshold
+        )
+        return Response(content=serialized, media_type=media_type)
+    except Exception as e:  # pragma: no cover
+        logging.exception("Transformation failed")
+        return Response(content=str(e), status_code=400)
+

--- a/src/strings2things/app/core/ontology_manager.py
+++ b/src/strings2things/app/core/ontology_manager.py
@@ -4,28 +4,33 @@ from strings2things.app.config import Settings
 from rdflib import Literal
 from rdflib import XSD
 
-settings = Settings()
-
 
 class OntologyManager:
     def __init__(self):
         self.graph = Graph()
         self.label_map: dict[str, str] = {}
+        # Defer settings creation until load time to avoid import-time failures
+        self.settings: Settings | None = None
 
     def load_ontologies(self):
+        # Initialize settings on first load
+        if self.settings is None:
+            self.settings = Settings()
+
         print(
-            f"[INFO] Connecting to SPARQL endpoint: {settings.ONTOLOGY_SPARQL_ENDPOINT}"
+            f"[INFO] Connecting to SPARQL endpoint: {self.settings.ONTOLOGY_SPARQL_ENDPOINT}"
         )
-        for graph_iri in settings.get_graph_iris():
+        for graph_iri in self.settings.get_graph_iris():
             print(f"[INFO] Loading named graph: {graph_iri}")
-            g = self._load_named_graph(settings.ONTOLOGY_SPARQL_ENDPOINT, graph_iri)
+            g = self._load_named_graph(self.settings.ONTOLOGY_SPARQL_ENDPOINT, graph_iri)
             self.graph += g
         print(f"[INFO] Loaded {len(self.graph)} triples.")
         self._build_label_map()
 
     def _load_named_graph(self, endpoint: str, graph_iri: str) -> Graph:
         sparql = SPARQLWrapper(endpoint)
-        sparql.setCredentials(settings.GRAPHDB_USERNAME, settings.GRAPHDB_PASSWORD)
+        assert self.settings is not None, "Settings must be initialized before loading ontologies"
+        sparql.setCredentials(self.settings.GRAPHDB_USERNAME, self.settings.GRAPHDB_PASSWORD)
         sparql.setQuery(
             f"""
             CONSTRUCT {{ ?s ?p ?o }}
@@ -80,7 +85,7 @@ class OntologyManager:
 
         if ambiguous_labels:
             msg = f"Found ambiguous labels: {', '.join(sorted(ambiguous_labels))} \n Please resolve these in your ontology before proceeding."
-            if settings.FAIL_ON_AMBIGUOUS_LABELS:
+            if (self.settings or Settings()).FAIL_ON_AMBIGUOUS_LABELS:
                 raise ValueError(msg)
             else:
                 print(f"[WARNING] {msg}")

--- a/src/strings2things/cli.py
+++ b/src/strings2things/cli.py
@@ -1,0 +1,104 @@
+"""Command Line Interface for strings2things.
+
+Provides:
+  - `strings2things serve` : Run the FastAPI application (uvicorn)
+  - `strings2things transform` : Transform an RDF input file (Turtle or JSON-LD)
+
+Installation (editable):
+    uv pip install -e .
+
+Examples:
+    strings2things serve --host 0.0.0.0 --port 8080
+    strings2things transform --input data.ttl --serialization jsonld --output out.jsonld
+
+Environment:
+  Ontology loading relies on environment variables (see config). Use `--no-ontology`
+  to run transformation without loading ontologies.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import typer
+import uvicorn
+from pathlib import Path
+from typing import Optional, Literal
+
+from strings2things.app.core.ontology_manager import OntologyManager
+from strings2things.app.core.rdf_transformer import RDFTransformer
+from strings2things.app.utils.rdf_utils import parse_rdf, serialize_rdf
+
+app = typer.Typer(help="CLI tools for the strings2things RDF transformer")
+
+
+def _load_label_map(disable: bool) -> dict[str, str]:
+    if disable:
+        return {}
+    manager = OntologyManager()
+    try:
+        manager.load_ontologies()
+    except Exception as e:  # pragma: no cover - resilience path
+        typer.echo(f"[warn] Ontology load failed: {e}", err=True)
+        return {}
+    return manager.get_label_map() or {}
+
+
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", help="Host interface"),
+    port: int = typer.Option(8000, help="Port to bind"),
+    reload: bool = typer.Option(False, help="Enable uvicorn reload (dev only)"),
+    log_level: str = typer.Option("info", help="Uvicorn log level"),
+):
+    """Run the FastAPI application via uvicorn."""
+    uvicorn.run(
+        "strings2things.app.main:app",
+        host=host,
+        port=port,
+        reload=reload,
+        log_level=log_level,
+    )
+
+
+@app.command()
+def transform(
+    input: Path = typer.Option(..., exists=True, dir_okay=False, readable=True, help="Input RDF file (Turtle or JSON-LD)"),
+    serialization: Literal["jsonld", "turtle"] = typer.Option(
+        ..., "--serialization", "-s", help="Output serialization format"
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Output file path (stdout if omitted)"
+    ),
+    fuzzy: bool = typer.Option(False, help="Enable fuzzy label matching"),
+    fuzzy_threshold: int = typer.Option(90, min=0, max=100, help="Fuzzy threshold 0-100"),
+    no_ontology: bool = typer.Option(
+        False, help="Disable ontology loading (use empty label map)"
+    ),
+):
+    """Transform an RDF graph from a local file and emit the result."""
+    data = input.read_bytes()
+    # Simple format inference
+    first = data.lstrip()[:1]
+    if first in (b"{", b"["):
+        in_format = "json-ld"
+    else:
+        in_format = "turtle"
+
+    graph = parse_rdf(data, format=in_format)
+    label_map = _load_label_map(disable=no_ontology)
+    transformer = RDFTransformer(label_map, fuzzy=fuzzy, fuzzy_threshold=fuzzy_threshold)
+    transformed = transformer.transform(graph)
+    out_fmt = "json-ld" if serialization == "jsonld" else "turtle"
+    serialized = serialize_rdf(transformed, output_format=out_fmt)
+
+    if output:
+        output.write_text(serialized, encoding="utf-8")
+    else:
+        typer.echo(serialized)
+
+
+def main():  # legacy entry point if needed
+    app()
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -798,6 +798,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +886,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031, upload-time = "2025-03-27T16:46:32.336Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077, upload-time = "2025-03-27T16:46:29.919Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1576,6 +1597,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.22.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1651,6 +1685,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec4e7f97488e67ab0d33add3efccb83a056cbafe3a2a6/setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6", size = 1343222, upload-time = "2025-01-08T18:28:23.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/8a/b9dc7678803429e4a3bc9ba462fa3dd9066824d3c607490235c6a796be5a/setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3", size = 1228782, upload-time = "2025-01-08T18:28:20.912Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1747,6 +1790,7 @@ dependencies = [
     { name = "rapidfuzz" },
     { name = "rdflib" },
     { name = "sparqlwrapper" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -1767,6 +1811,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "rdflib", specifier = ">=7.1.4" },
     { name = "sparqlwrapper", specifier = ">=2.0.0" },
+    { name = "typer", specifier = ">=0.12.5" },
 ]
 
 [package.metadata.requires-dev]
@@ -1835,6 +1880,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed Changes

This PR refactors and enhances the RDF transformation API by splitting input modalities into two explicit endpoints, adding native raw Turtle support (without JSON wrapping), enforcing an explicit output serialization parameter, and improving OpenAPI clarity.

### Summary of Key Improvements

1. Introduced two endpoints for clearer API usage and documentation:
   - `POST /v1/things` — Raw body (JSON-LD object/array or Turtle string).
   - `POST /v1/things/upload` — Multipart file upload.
2. Added support for sending plain Turtle directly (`Content-Type: text/turtle` or `text/plain`) without wrapping it in JSON.
3. Made `serialization` a mandatory parameter (`jsonld` | `turtle`) across both endpoints.
4. Preserved and documented fuzzy matching parameters:
   - `fuzzy` (bool, default `false`)
   - `fuzzy_threshold` (int, 0–100, default `90`)
5. Added explicit multi–media type request body documentation for the raw endpoint (JSON-LD + Turtle).
6. Implemented resilient lazy ontology loading (continues with an empty label map if ontologies fail to load).
7. Separated multipart handling to avoid Swagger/OpenAPI collapsing all input options into a single `multipart/form-data` representation.
8. Improved developer ergonomics with clearer error responses (`400` for empty bodies or malformed content).

### Rationale

Previously a single endpoint attempted to multiplex raw JSON, Turtle, and file uploads. Because FastAPI/OpenAPI only allows one requestBody schema per operation, the presence of a `File` parameter degraded the generated docs—Swagger showed only `multipart/form-data`, obscuring JSON-LD/Turtle raw usage. Splitting the endpoints yields explicit, self-documenting API surfaces and reduces client ambiguity.

### Backward Compatibility

- The old combined behavior (file + raw in one call) is replaced by two dedicated endpoints.
- Existing clients using file upload must update the path to: `POST /v1/things/upload`.
- Raw JSON-LD/Turtle clients gain clarity and no longer need to guess correct body formats.

---

## Types of Changes

- [x] A new **feature** (non-breaking change which adds functionality). Use MR tag `feature`.
- [ ] A **bug fix**
- [ ] A **breaking change**
- [ ] A **non-productive** update

(Arguably a minor breaking path change for file uploads if they previously used `/v1/things`; if your release policy treats endpoint path changes as breaking, tick breaking instead.)

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/sdsc-ordes/strings-to-things/tree/main/CONTRIBUTING.md) guidelines.

---

## API Specification (Delta)

### 1. Raw Transformation Endpoint

`POST /v1/things`

Accepts one of:
- `application/ld+json` — JSON-LD object/array
- `application/json` — Interpreted as JSON-LD
- `text/turtle` — Turtle string
- `text/plain` — Treated as Turtle if parsable

Query Parameters:
| Name            | Type    | Required | Values              | Description                               |
|-----------------|---------|----------|---------------------|-------------------------------------------|
| `serialization` | string  | yes      | `jsonld` \| `turtle` | Output format                             |
| `fuzzy`         | boolean | no       |                     | Enable fuzzy label matching               |
| `fuzzy_threshold` | integer | no     | 0–100 (default 90)  | Minimum fuzzy score to accept             |

Successful Responses:
- `200 OK` — RDF graph serialized as:
  - `application/ld+json` if `serialization=jsonld`
  - `text/turtle` if `serialization=turtle`

Error Responses:
- `400 Bad Request` — Empty body, parse failure, or transformation error.

### 2. Multipart Upload Endpoint

`POST /v1/things/upload`

Consumes: `multipart/form-data`

Form Fields:
| Name             | Type    | Required | Description                              |
|------------------|---------|----------|------------------------------------------|
| `file`           | file    | yes      | RDF file (JSON-LD or Turtle)             |
| `serialization`  | string  | yes      | `jsonld` \| `turtle`                     |
| `fuzzy`          | boolean | no       | Enable fuzzy label matching              |
| `fuzzy_threshold`| integer | no       | 0–100, default 90                        |

Responses: Same as raw endpoint.

---

## OpenAPI Snippet (Representative)

```yaml
paths:
  /v1/things:
    post:
      summary: Transform RDF (raw body)
      parameters:
        - in: query
          name: serialization
          required: true
          schema: { type: string, enum: [jsonld, turtle] }
        - in: query
          name: fuzzy
          required: false
          schema: { type: boolean, default: false }
        - in: query
          name: fuzzy_threshold
          required: false
          schema: { type: integer, minimum: 0, maximum: 100, default: 90 }
      requestBody:
        required: true
        content:
          application/ld+json:
            schema:
              type: object
          application/json:
            schema:
              type: object
          text/turtle:
            schema:
              type: string
          text/plain:
            schema:
              type: string
      responses:
        '200':
          description: Transformed RDF
          content:
            application/ld+json:
              schema: { type: object }
            text/turtle:
              schema: { type: string }
        '400':
            description: Invalid input or processing error
  /v1/things/upload:
    post:
      summary: Transform RDF (file upload)
      requestBody:
        required: true
        content:
          multipart/form-data:
            schema:
              type: object
              required: [file, serialization]
              properties:
                file:
                  type: string
                  format: binary
                serialization:
                  type: string
                  enum: [jsonld, turtle]
                fuzzy:
                  type: boolean
                  default: false
                fuzzy_threshold:
                  type: integer
                  minimum: 0
                  maximum: 100
                  default: 90
      responses:
        '200':
          description: Transformed RDF
          content:
            application/ld+json:
              schema: { type: object }
            text/turtle:
              schema: { type: string }
        '400':
          description: Invalid input or processing error
```
          
          
### Internal Implementation Notes

Refactored raw handler to read request.body() (byte-level) allowing flexible media types.
Heuristic fallback for format detection: leading { or [ => JSON-LD else Turtle.
serialization drives only output format; input autodetected.
Centralized _transform_bytes() pipeline ensures consistent logic across endpoints.
Logging captures ontology load failures without aborting transformation.

### Testing Recommendations (Follow-Up PR)

Add tests for:
Raw JSON-LD → Turtle output
Raw Turtle → JSON-LD output
Multipart JSON-LD & Turtle flows
Fuzzy match ON vs OFF (with mock label map)
Mock OntologyManager in unit tests to avoid external SPARQL dependencies.
